### PR TITLE
fix(frontend): runtime proxy routes (fixes prod images + CV) + inner-nav/doc-block tweaks

### DIFF
--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,0 +1,18 @@
+import type { NextRequest } from "next/server";
+import { proxyTo } from "@/lib/proxy";
+
+export const dynamic = "force-dynamic";
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+async function handle(req: NextRequest, ctx: Ctx) {
+  return proxyTo(req, "api", (await ctx.params).path);
+}
+
+export const GET = handle;
+export const HEAD = handle;
+export const POST = handle;
+export const PUT = handle;
+export const PATCH = handle;
+export const DELETE = handle;
+export const OPTIONS = handle;

--- a/frontend/app/documents/[...path]/route.ts
+++ b/frontend/app/documents/[...path]/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from "next/server";
+import { proxyTo } from "@/lib/proxy";
+
+export const dynamic = "force-dynamic";
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+export async function GET(req: NextRequest, ctx: Ctx) {
+  return proxyTo(req, "documents", (await ctx.params).path);
+}
+
+export const HEAD = GET;

--- a/frontend/app/media/[...path]/route.ts
+++ b/frontend/app/media/[...path]/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from "next/server";
+import { proxyTo } from "@/lib/proxy";
+
+export const dynamic = "force-dynamic";
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+export async function GET(req: NextRequest, ctx: Ctx) {
+  return proxyTo(req, "media", (await ctx.params).path);
+}
+
+export const HEAD = GET;

--- a/frontend/app/resume/[...path]/route.ts
+++ b/frontend/app/resume/[...path]/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from "next/server";
+import { proxyTo } from "@/lib/proxy";
+
+export const dynamic = "force-dynamic";
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+// /resume/pdf returns a 302 to /documents/<id>/<file>; proxyTo passes the
+// redirect through with its relative Location, so the browser re-enters the
+// /documents route handler for the actual file.
+export async function GET(req: NextRequest, ctx: Ctx) {
+  return proxyTo(req, "resume", (await ctx.params).path);
+}
+
+export const HEAD = GET;

--- a/frontend/components/InnerHeader.tsx
+++ b/frontend/components/InnerHeader.tsx
@@ -15,12 +15,6 @@ export default function InnerHeader() {
           >
             ← back
           </Link>
-          <Link
-            href="/blog"
-            className="font-mono text-[12.5px] text-muted transition hover:text-ink"
-          >
-            blog
-          </Link>
           <ThemeToggle />
         </div>
       </nav>

--- a/frontend/components/streamfield/StreamField.tsx
+++ b/frontend/components/streamfield/StreamField.tsx
@@ -190,18 +190,28 @@ function block(b: StreamBlock): React.ReactNode {
         <div className="my-6 rounded-xl border border-border bg-surface p-5">
           {v.title ? <p className="font-display text-[18px] font-medium">{v.title as string}</p> : null}
           {v.description ? <p className="mb-3 text-[14px] text-muted">{v.description as string}</p> : null}
-          <div className="flex flex-wrap gap-x-2 gap-y-3">
+          <div className="flex flex-wrap gap-x-4 gap-y-3">
             {docs.map((d, i) =>
               d.url ? (
-                <span key={i} className="flex flex-col gap-0.5">
-                  <a
-                    href={mediaUrl(d.url)}
-                    target={d.open_in_new ? "_blank" : undefined}
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 rounded-md bg-mint px-3 py-1.5 font-mono text-[12px] text-chip-ink transition hover:-translate-y-0.5"
-                  >
-                    ↓ {d.label || "PDF"}
-                  </a>
+                <span key={i} className="flex flex-col gap-1">
+                  <span className="flex items-center gap-1.5">
+                    <span className="font-mono text-[12px] text-ink">{d.label || "PDF"}</span>
+                    <a
+                      href={mediaUrl(d.url)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 rounded-md bg-mint px-2.5 py-1.5 font-mono text-[11.5px] text-chip-ink transition hover:-translate-y-0.5"
+                    >
+                      ⤢ view
+                    </a>
+                    <a
+                      href={mediaUrl(d.url)}
+                      download
+                      className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 font-mono text-[11.5px] text-muted transition hover:-translate-y-0.5 hover:text-ink"
+                    >
+                      ↓ download
+                    </a>
+                  </span>
                   {d.note ? <span className="text-[11px] text-muted">{d.note}</span> : null}
                 </span>
               ) : null,

--- a/frontend/lib/proxy.ts
+++ b/frontend/lib/proxy.ts
@@ -1,0 +1,63 @@
+import type { NextRequest } from "next/server";
+
+// Resolved at REQUEST time (route handlers run in the Node runtime), so the
+// in-cluster backend URL comes from the container env — unlike next.config
+// rewrites, whose destination is frozen at build time.
+function backend(): string {
+  return (
+    process.env.INTERNAL_API_URL ||
+    process.env.WAGTAIL_API_URL ||
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+}
+
+const HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+]);
+
+/**
+ * Proxy a browser request to the in-cluster backend, streaming the response
+ * back. Redirects pass through verbatim (Location stays relative, so the
+ * browser re-enters the proxy for the next hop, e.g. /resume -> /documents).
+ */
+export async function proxyTo(
+  req: NextRequest,
+  prefix: string,
+  segments: string[],
+): Promise<Response> {
+  const target = `${backend()}/${prefix}/${segments.join("/")}${req.nextUrl.search}`;
+
+  const headers = new Headers();
+  req.headers.forEach((v, k) => {
+    if (!HOP.has(k.toLowerCase())) headers.set(k, v);
+  });
+
+  const init: RequestInit = { method: req.method, headers, redirect: "manual" };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = await req.arrayBuffer();
+  }
+
+  const res = await fetch(target, init);
+
+  const out = new Headers();
+  res.headers.forEach((v, k) => {
+    const key = k.toLowerCase();
+    // fetch already decoded the body; let the runtime recompute length/encoding.
+    if (HOP.has(key) || key === "content-encoding" || key === "content-length") return;
+    out.set(k, v);
+  });
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: out,
+  });
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,29 +1,14 @@
 import type { NextConfig } from "next";
 
-// Internal/in-cluster backend address. The browser never sees this — it only
-// ever talks to the frontend origin, which proxies these paths to the backend.
-// Set INTERNAL_API_URL in production (e.g. http://portfolio-web:8000).
-const INTERNAL_API_URL = (
-  process.env.INTERNAL_API_URL ||
-  process.env.WAGTAIL_API_URL ||
-  "http://localhost:3000"
-).replace(/\/$/, "");
-
 const nextConfig: NextConfig = {
   // Self-contained server bundle for a small production Docker image.
   output: "standalone",
 
-  // Proxy browser-facing backend paths (API, media, documents, CV) through the
-  // frontend so the backend can stay in-network only. /cms and the rest of the
-  // Django surface are intentionally NOT proxied.
-  async rewrites() {
-    return [
-      { source: "/api/:path*", destination: `${INTERNAL_API_URL}/api/:path*` },
-      { source: "/media/:path*", destination: `${INTERNAL_API_URL}/media/:path*` },
-      { source: "/documents/:path*", destination: `${INTERNAL_API_URL}/documents/:path*` },
-      { source: "/resume/:path*", destination: `${INTERNAL_API_URL}/resume/:path*` },
-    ];
-  },
+  // Browser-facing backend paths (/api, /media, /documents, /resume) are
+  // proxied to the in-cluster backend by Route Handlers (app/*/[...path]/route.ts),
+  // NOT next.config rewrites — rewrite destinations are frozen at build time, so
+  // they'd bake in localhost. Route Handlers read INTERNAL_API_URL at request
+  // time. /cms and the rest of the Django surface are intentionally not proxied.
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Why
Production images were dead and `/resume/pdf` returned 500. Root cause: `next.config.ts` `rewrites()` destinations are frozen into `.next/required-server-files.json` at **build** time, so `INTERNAL_API_URL` (unset in CI) baked in as `localhost:3000`. The standalone prod server proxied `/media`, `/resume`, `/api` to localhost → nothing there → 500. SSR was fine because it reads the runtime env directly.

## Fix
Replace the rewrites with **Route Handlers** (`app/{media,documents,resume,api}/[...path]/route.ts`) that run in the Node runtime and resolve `INTERNAL_API_URL` at **request** time, streaming the backend response back. Redirects pass through with relative `Location`, so `/resume/pdf` → `/documents/<id>/<file>` re-enters the proxy.

Verified against the standalone build with a mock backend: `/media`, `/documents`, `/resume/pdf` (302), `/api` all proxy correctly.

## Also in this PR
- **InnerHeader**: drop the `blog` nav link — on mobile it pushed `rafael.duarte-correia()` to a second line. Keeps `← back` + theme/color toggle.
- **pdfs block**: distinct **view** (inline, new tab) and **download** buttons per document instead of one ambiguous link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)