### PR TITLE
home: education blurb, interactive skills, public-commits label

### DIFF
--- a/frontend/components/sections/About.tsx
+++ b/frontend/components/sections/About.tsx
@@ -36,7 +36,7 @@ export default function About({
   if (stats.stat_followers && github?.followers != null)
     facts.push({ label: "followers", value: String(github.followers) });
   if (stats.stat_commits && github?.total_commits != null)
-    facts.push({ label: "commits", value: github.total_commits.toLocaleString() });
+    facts.push({ label: "public commits", value: github.total_commits.toLocaleString() });
   if (stats.stat_publications && publications.flat.length)
     facts.push({ label: "publications", value: String(publications.flat.length) });
   if (stats.stat_honors && awards.length)

--- a/frontend/components/sections/Skills.tsx
+++ b/frontend/components/sections/Skills.tsx
@@ -1,8 +1,13 @@
+"use client";
+
+import { useState } from "react";
 import type { SiteBundle } from "@/lib/types";
 import Eyebrow from "../Eyebrow";
 import Reveal from "../Reveal";
 
 const BIO = /biolog|genetic|ecolog|evolu|physiolog|microbio|organism|taxonom|molecular|anatom/i;
+
+type Cat = "bio" | "comp";
 
 export default function Skills({
   bundle,
@@ -14,7 +19,11 @@ export default function Skills({
   title?: string;
 }) {
   const skills = bundle.skills;
+  // Clicking a tag (or a legend entry) highlights that category, dims the rest.
+  const [active, setActive] = useState<Cat | null>(null);
   if (!skills.length) return null;
+
+  const toggle = (c: Cat) => setActive((prev) => (prev === c ? null : c));
 
   return (
     <section id="skills" className="border-b border-border py-24">
@@ -23,33 +32,59 @@ export default function Skills({
           <Eyebrow centered>§{num} — {title || bundle.copy.skills_title || "Skills"}</Eyebrow>
         </Reveal>
         <Reveal>
-          <div className="mb-[22px] flex justify-center gap-[18px] font-mono text-[11.5px] text-muted">
-            <span>
+          <div className="mb-[22px] flex justify-center gap-[18px] font-mono text-[11.5px]">
+            <button
+              type="button"
+              onClick={() => toggle("comp")}
+              aria-pressed={active === "comp"}
+              className={`transition ${active === "comp" ? "text-ink" : "text-muted hover:text-ink"}`}
+            >
               <i className="mr-[6px] inline-block h-[9px] w-[9px] rounded-full align-middle bg-comp" />
               computational
-            </span>
-            <span>
+            </button>
+            <button
+              type="button"
+              onClick={() => toggle("bio")}
+              aria-pressed={active === "bio"}
+              className={`transition ${active === "bio" ? "text-ink" : "text-muted hover:text-ink"}`}
+            >
               <i className="mr-[6px] inline-block h-[9px] w-[9px] rounded-full align-middle bg-bio" />
               biology
-            </span>
+            </button>
           </div>
         </Reveal>
         <Reveal>
           <div className="mx-auto flex max-w-[860px] flex-wrap justify-center gap-3">
-            {skills.map((s) => (
-              <div
-                key={s.name}
-                title={s.description}
-                className="flex items-center gap-[10px] rounded-[11px] border border-border bg-surface px-[15px] py-[11px] text-[14px] transition hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)]"
-              >
-                <span
-                  className={`h-[9px] w-[9px] flex-none rounded-full ${
-                    BIO.test(s.name) ? "bg-bio" : "bg-comp"
-                  }`}
-                />
-                {s.name}
-              </div>
-            ))}
+            {skills.map((s) => {
+              const cat: Cat = BIO.test(s.name) ? "bio" : "comp";
+              const dim = active !== null && active !== cat;
+              const hot = active === cat;
+              return (
+                <button
+                  key={s.name}
+                  type="button"
+                  onClick={() => toggle(cat)}
+                  className={`group relative flex items-center gap-[10px] rounded-[11px] border bg-surface px-[15px] py-[11px] text-[14px] transition duration-150 hover:-translate-y-0.5 hover:shadow-[var(--shadow)] ${
+                    hot ? "border-primary shadow-[var(--shadow)]" : "border-border hover:border-primary"
+                  } ${dim ? "opacity-40" : "opacity-100"}`}
+                >
+                  <span
+                    className={`h-[9px] w-[9px] flex-none rounded-full ${
+                      cat === "bio" ? "bg-bio" : "bg-comp"
+                    }`}
+                  />
+                  {s.name}
+                  {s.description && (
+                    <span
+                      role="tooltip"
+                      className="pointer-events-none absolute bottom-[calc(100%+8px)] left-1/2 z-30 w-max max-w-[240px] -translate-x-1/2 translate-y-1 rounded-lg border border-border bg-surface px-3 py-2 text-left text-[12.5px] font-normal leading-snug text-ink opacity-0 shadow-[var(--shadow)] transition duration-100 group-hover:translate-y-0 group-hover:opacity-100"
+                    >
+                      {s.description}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
         </Reveal>
       </div>

--- a/frontend/components/sections/Timeline.tsx
+++ b/frontend/components/sections/Timeline.tsx
@@ -11,11 +11,13 @@ function Item({
   title,
   org,
   range,
+  blurb,
   bullets,
 }: {
   title: string;
   org: string;
   range: string;
+  blurb?: string;
   bullets?: string[];
 }) {
   return (
@@ -27,6 +29,7 @@ function Item({
       <p className="m-0 mb-[6px] text-[13.5px] text-muted">
         <em>{org}</em>
       </p>
+      {blurb && <p className="m-0 mb-[6px] text-[13.5px]">{blurb}</p>}
       {bullets && bullets.length > 0 && (
         <ul className="mt-2 list-disc pl-[18px] text-[13.5px]">
           {bullets.map((b, i) => (
@@ -80,6 +83,7 @@ export default function Timeline({
                     title={x.role}
                     org={`${x.company}${x.location ? ` · ${x.location}` : ""}`}
                     range={years(x.start_year, x.end_year)}
+                    blurb={x.blurb}
                     bullets={x.bullets}
                   />
                 ))}
@@ -98,6 +102,7 @@ export default function Timeline({
                     title={e.title}
                     org={`${e.institution}${e.location ? ` · ${e.location}` : ""}`}
                     range={years(e.start_year, e.end_year)}
+                    blurb={e.blurb}
                   />
                 ))}
               </Stream>


### PR DESCRIPTION
Small home-page polish.

- **Education blurb** now renders. The Timeline `Item` only rendered `bullets`; education has a `blurb` (no bullets), so it showed nothing. Now the blurb renders for both education and experience.
- **Interactive skills.** Clicking a skill tag (or a legend entry) highlights that category — computational or biology — and dims the rest; click again to clear.
- **Faster/cleaner skill hover.** Replaced the slow native `title` tooltip with a custom instant styled card showing the skill description.
- **"public commits"** — relabeled the commits stat; the count is from `search/commits` (public repos only), so the label now says so.

Frontend-only, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)