### PR TITLE
fix(home): timeline inline markdown + solid skill tooltip

### DIFF
--- a/frontend/components/sections/Skills.tsx
+++ b/frontend/components/sections/Skills.tsx
@@ -77,7 +77,7 @@ export default function Skills({
                   {s.description && (
                     <span
                       role="tooltip"
-                      className="pointer-events-none absolute bottom-[calc(100%+8px)] left-1/2 z-30 w-max max-w-[240px] -translate-x-1/2 translate-y-1 rounded-lg border border-border bg-surface px-3 py-2 text-left text-[12.5px] font-normal leading-snug text-ink opacity-0 shadow-[var(--shadow)] transition duration-100 group-hover:translate-y-0 group-hover:opacity-100"
+                      className="pointer-events-none invisible absolute bottom-[calc(100%+8px)] left-1/2 z-50 w-max max-w-[240px] -translate-x-1/2 translate-y-1 rounded-lg border border-border bg-surface px-3 py-2 text-left text-[12.5px] font-normal leading-snug text-ink shadow-[var(--shadow)] transition duration-100 group-hover:visible group-hover:translate-y-0"
                     >
                       {s.description}
                     </span>

--- a/frontend/components/sections/Timeline.tsx
+++ b/frontend/components/sections/Timeline.tsx
@@ -1,5 +1,6 @@
 import type { SiteBundle, Education, Experience } from "@/lib/types";
 import { mediaUrl } from "@/lib/api";
+import { inline } from "@/lib/inline";
 import Eyebrow from "../Eyebrow";
 import Reveal from "../Reveal";
 
@@ -29,12 +30,12 @@ function Item({
       <p className="m-0 mb-[6px] text-[13.5px] text-muted">
         <em>{org}</em>
       </p>
-      {blurb && <p className="m-0 mb-[6px] text-[13.5px]">{blurb}</p>}
+      {blurb && <p className="m-0 mb-[6px] text-[13.5px]">{inline(blurb)}</p>}
       {bullets && bullets.length > 0 && (
         <ul className="mt-2 list-disc pl-[18px] text-[13.5px]">
           {bullets.map((b, i) => (
             <li key={i} className="mb-1">
-              {b}
+              {inline(b)}
             </li>
           ))}
         </ul>

--- a/frontend/lib/inline.tsx
+++ b/frontend/lib/inline.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+// Minimal inline-markdown renderer for plain-text CMS fields that may contain
+// **bold**, *italic*/_italic_, `code`, and [text](url). These fields are not
+// RichText, so the raw markers would otherwise render literally.
+const TOKEN = /(\*\*[^*]+\*\*|\*[^*]+\*|_[^_]+_|`[^`]+`|\[[^\]]+\]\([^)]+\))/g;
+
+export function inline(text: string): React.ReactNode {
+  if (!text) return text;
+  const parts = text.split(TOKEN);
+  return parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**"))
+      return <strong key={i}>{part.slice(2, -2)}</strong>;
+    if (part.startsWith("*") && part.endsWith("*"))
+      return <em key={i}>{part.slice(1, -1)}</em>;
+    if (part.startsWith("_") && part.endsWith("_"))
+      return <em key={i}>{part.slice(1, -1)}</em>;
+    if (part.startsWith("`") && part.endsWith("`"))
+      return (
+        <code key={i} className="rounded bg-hl px-1 py-0.5 font-mono text-[0.9em]">
+          {part.slice(1, -1)}
+        </code>
+      );
+    const link = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+    if (link)
+      return (
+        <a
+          key={i}
+          href={link[2]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary-ink underline underline-offset-2"
+        >
+          {link[1]}
+        </a>
+      );
+    return part;
+  });
+}


### PR DESCRIPTION
## What
- **Timeline markdown**: blurb/bullets are plain-text CMS fields, so `**bold**` and `*italic*` showed literal asterisks. Added a small inline-markdown renderer (`lib/inline.tsx`) handling bold, italic, `code`, and links, applied to experience/education blurbs and bullets.
- **Skill tooltip**: it faded in via `opacity`, which made the entire card (background too) translucent during the transition, so adjacent tags bled through. Now it toggles via `visibility` + translate with a fully opaque `bg-surface`, and sits at `z-50` above sibling tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)